### PR TITLE
Added stat variance and bug-fixed type resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@
 *.sa*
 *.swo
 *.swp
+*.ss*
 *.til
 .fuse*
 .idea/

--- a/include/random.h
+++ b/include/random.h
@@ -9,6 +9,7 @@ extern u32 gRng2Value;
 //Returns a 16-bit pseudorandom number
 u16 Random(void);
 u16 Random2(void);
+u32 SeededRandom(u32 seed);
 
 //Returns a 32-bit pseudorandom number
 #define Random32() (Random() | (Random() << 16))

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -2509,8 +2509,8 @@ void FaintClearSetData(void)
         *(i * 8 + gActiveBattler * 2 + (u8 *)(gBattleStruct->lastTakenMoveFrom) + 1) = 0;
     }
     gBattleResources->flags->flags[gActiveBattler] = 0;
-    gBattleMons[gActiveBattler].type1 = DeriveDynamicTyping(gSpeciesInfo[gBattleMons[gActiveBattler].species].types[0], gSpeciesInfo[gBattleMons[gActiveBattler].species].types[1], GetMonData(&gPlayerParty[gBattlerPartyIndexes[gActiveBattler]], MON_DATA_PERSONALITY), 1);
-    gBattleMons[gActiveBattler].type2 = DeriveDynamicTyping(gSpeciesInfo[gBattleMons[gActiveBattler].species].types[0], gSpeciesInfo[gBattleMons[gActiveBattler].species].types[1], GetMonData(&gPlayerParty[gBattlerPartyIndexes[gActiveBattler]], MON_DATA_PERSONALITY), 0);
+    gBattleMons[gActiveBattler].type1 = DeriveDynamicTyping(gSpeciesInfo[gBattleMons[gActiveBattler].species].types[0], gSpeciesInfo[gBattleMons[gActiveBattler].species].types[1], gBattleMons[gActiveBattler].personality, 1);
+    gBattleMons[gActiveBattler].type2 = DeriveDynamicTyping(gSpeciesInfo[gBattleMons[gActiveBattler].species].types[0], gSpeciesInfo[gBattleMons[gActiveBattler].species].types[1], gBattleMons[gActiveBattler].personality, 0);
     //gBattleMons[gActiveBattler].type1 = gSpeciesInfo[gBattleMons[gActiveBattler].species].types[0];
     //gBattleMons[gActiveBattler].type2 = gSpeciesInfo[gBattleMons[gActiveBattler].species].types[1];
 }
@@ -2576,8 +2576,8 @@ static void BattleIntroDrawTrainersOrMonsSprites(void)
             for (i = 0; i < sizeof(struct BattlePokemon); i++)
                 ptr[i] = gBattleBufferB[gActiveBattler][4 + i];
 
-            gBattleMons[gActiveBattler].type1 = DeriveDynamicTyping(gSpeciesInfo[gBattleMons[gActiveBattler].species].types[0], gSpeciesInfo[gBattleMons[gActiveBattler].species].types[1], GetMonData(&gPlayerParty[gBattlerPartyIndexes[gActiveBattler]], MON_DATA_PERSONALITY), 1);
-            gBattleMons[gActiveBattler].type2 = DeriveDynamicTyping(gSpeciesInfo[gBattleMons[gActiveBattler].species].types[0], gSpeciesInfo[gBattleMons[gActiveBattler].species].types[1], GetMonData(&gPlayerParty[gBattlerPartyIndexes[gActiveBattler]], MON_DATA_PERSONALITY), 0);
+            gBattleMons[gActiveBattler].type1 = DeriveDynamicTyping(gSpeciesInfo[gBattleMons[gActiveBattler].species].types[0], gSpeciesInfo[gBattleMons[gActiveBattler].species].types[1], gBattleMons[gActiveBattler].personality, 1);
+            gBattleMons[gActiveBattler].type2 = DeriveDynamicTyping(gSpeciesInfo[gBattleMons[gActiveBattler].species].types[0], gSpeciesInfo[gBattleMons[gActiveBattler].species].types[1], gBattleMons[gActiveBattler].personality, 0);
 
             //gBattleMons[gActiveBattler].type1 = gSpeciesInfo[gBattleMons[gActiveBattler].species].types[0];
             //gBattleMons[gActiveBattler].type2 = gSpeciesInfo[gBattleMons[gActiveBattler].species].types[1];
@@ -3166,8 +3166,8 @@ static void HandleTurnActionSelectionState(void)
                         struct ChooseMoveStruct moveInfo;
 
                         moveInfo.species = gBattleMons[gActiveBattler].species;
-                        moveInfo.monType1 = DeriveDynamicTyping(gSpeciesInfo[gBattleMons[gActiveBattler].species].types[0], gSpeciesInfo[gBattleMons[gActiveBattler].species].types[1], GetMonData(&gPlayerParty[gBattlerPartyIndexes[gActiveBattler]], MON_DATA_PERSONALITY), 1);
-                        moveInfo.monType2 = DeriveDynamicTyping(gSpeciesInfo[gBattleMons[gActiveBattler].species].types[0], gSpeciesInfo[gBattleMons[gActiveBattler].species].types[1], GetMonData(&gPlayerParty[gBattlerPartyIndexes[gActiveBattler]], MON_DATA_PERSONALITY), 0);
+                        moveInfo.monType1 = DeriveDynamicTyping(gSpeciesInfo[gBattleMons[gActiveBattler].species].types[0], gSpeciesInfo[gBattleMons[gActiveBattler].species].types[1], gBattleMons[gActiveBattler].personality, 1);
+                        moveInfo.monType2 = DeriveDynamicTyping(gSpeciesInfo[gBattleMons[gActiveBattler].species].types[0], gSpeciesInfo[gBattleMons[gActiveBattler].species].types[1], gBattleMons[gActiveBattler].personality, 0);
                         //moveInfo.monType1 = gBattleMons[gActiveBattler].type1;
                         //moveInfo.monType2 = gBattleMons[gActiveBattler].type2;
                         for (i = 0; i < MAX_MON_MOVES; i++)

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -4483,8 +4483,8 @@ static void Cmd_switchindataupdate(void)
     for (i = 0; i < sizeof(struct BattlePokemon); i++)
         monData[i] = gBattleBufferB[gActiveBattler][4 + i];
 
-    gBattleMons[gActiveBattler].type1 = DeriveDynamicTyping(gSpeciesInfo[gBattleMons[gActiveBattler].species].types[0], gSpeciesInfo[gBattleMons[gActiveBattler].species].types[1], GetMonData(&gPlayerParty[gBattlerPartyIndexes[gActiveBattler]], MON_DATA_PERSONALITY), 1);
-    gBattleMons[gActiveBattler].type2 = DeriveDynamicTyping(gSpeciesInfo[gBattleMons[gActiveBattler].species].types[0], gSpeciesInfo[gBattleMons[gActiveBattler].species].types[1], GetMonData(&gPlayerParty[gBattlerPartyIndexes[gActiveBattler]], MON_DATA_PERSONALITY), 0);
+    gBattleMons[gActiveBattler].type1 = DeriveDynamicTyping(gSpeciesInfo[gBattleMons[gActiveBattler].species].types[0], gSpeciesInfo[gBattleMons[gActiveBattler].species].types[1], gBattleMons[gActiveBattler].personality, 1);
+    gBattleMons[gActiveBattler].type2 = DeriveDynamicTyping(gSpeciesInfo[gBattleMons[gActiveBattler].species].types[0], gSpeciesInfo[gBattleMons[gActiveBattler].species].types[1], gBattleMons[gActiveBattler].personality, 0);
     //gBattleMons[gActiveBattler].type1 = gSpeciesInfo[gBattleMons[gActiveBattler].species].types[0];
     //gBattleMons[gActiveBattler].type2 = gSpeciesInfo[gBattleMons[gActiveBattler].species].types[1];
     gBattleMons[gActiveBattler].ability = GetAbilityBySpecies(gBattleMons[gActiveBattler].species, gBattleMons[gActiveBattler].abilityNum);

--- a/src/random.c
+++ b/src/random.c
@@ -12,6 +12,11 @@ u16 Random(void)
     return gRngValue >> 16;
 }
 
+u32 SeededRandom(u32 seed)
+{
+    return ISO_RANDOMIZE1(seed);
+}
+
 void SeedRng(u16 seed)
 {
     gRngValue = seed;


### PR DESCRIPTION
Adds seeded random value function and generates stat variance using personality value as the original seed. Stats can vary within the range of -15% to +30% of their original value for a given pokemon. This creates much greater variance in the wild pokemon found, and can compliment some type combos better.